### PR TITLE
Adds check in eo_get_event_meta_list for tax error

### DIFF
--- a/includes/event-organiser-event-functions.php
+++ b/includes/event-organiser-event-functions.php
@@ -1543,7 +1543,7 @@ function eo_get_event_meta_list( $event_id = 0 ) {
 		);
 	}
 
-	if ( get_the_terms( $event_id, 'event-category' ) ) {
+	if ( get_the_terms( $event_id, 'event-category' ) && !is_wp_error( get_the_terms( $event_id, 'event-category' ) ) ) {
 		$html .= sprintf(
 			'<li><strong>%s:</strong> %s</li>' . "\n",
 			__( 'Categories', 'eventorganiser' ),


### PR DESCRIPTION
If event-category taxonomy is disabled there will be an WP Error that should be checked too - same as for event-tag